### PR TITLE
Add reusable workflows to check PRs for DCO signoffs, plus CONTRIBUTING guide

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -1,0 +1,45 @@
+# Unprivileged first part of dco-report.yml.  Architecture and code from
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+#
+# Invoke with:
+#
+#     name: DCO
+#     on:
+#       pull_request:
+#         branches: [main]
+#     permissions:
+#       contents: read
+#     jobs:
+#       check:
+#         name: Organization
+#         uses: openslide/.github/.github/workflows/dco-check.yml@main
+
+name: DCO (reusable)
+
+on:
+  workflow_call:
+
+jobs:
+  check:
+    name: Check signoffs
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v3
+    - name: Install dco-check
+      run: pip install dco-check
+    - name: Check signoffs
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        mkdir result
+        echo ${{ github.event.number }} > result/pr
+        echo ${{ github.event.pull_request.base.sha }} > result/base
+        echo ${{ github.event.pull_request.head.sha }} > result/head
+        dco-check -v
+        touch result/success
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: result
+        path: result

--- a/.github/workflows/dco-report.yml
+++ b/.github/workflows/dco-report.yml
@@ -1,0 +1,132 @@
+# Privileged second part of dco-check.yml.  Architecture and code from
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+#
+# Invoke with:
+#
+#     name: DCO report
+#     on:
+#       workflow_run:
+#         workflows: ["DCO"]
+#         types:
+#           - completed
+#     permissions:
+#       pull-requests: write
+#     jobs:
+#       comment:
+#         name: Organization
+#         uses: openslide/.github/.github/workflows/dco-report.yml@main
+
+name: DCO report (reusable)
+
+on:
+  workflow_call:
+
+jobs:
+  comment:
+    name: Post PR comment
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    steps:
+      - name: Download state
+        uses: actions/github-script@v6
+        with:
+          script: |
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "result"
+            })[0];
+            var download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{ github.workspace }}/result.zip', Buffer.from(download.data));
+
+      - name: Read state
+        id: result
+        run: |
+          unzip -d result result.zip
+          echo "::set-output name=pr::$(cat result/pr)"
+          echo "::set-output name=base::$(cat result/base)"
+          echo "::set-output name=head::$(cat result/head)"
+          if [ -e result/success ]; then
+              echo "::set-output name=success::true"
+          fi
+
+      - name: Find existing comment
+        uses: peter-evans/find-comment@v2
+        id: search
+        continue-on-error: true
+        with:
+          issue-number: ${{ steps.result.outputs.pr }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Developer Certificate of Origin
+
+      - name: Report good signoff
+        uses: peter-evans/create-or-update-comment@v2
+        if: steps.result.outputs.success == 'true'
+        with:
+          issue-number: ${{ steps.result.outputs.pr }}
+          comment-id: ${{ steps.search.outputs.comment-id }}
+          edit-mode: replace
+          body: >
+            ## DCO signed off :heavy_check_mark:
+
+
+            [All commits][commits] have been [signed off][signoff].  You have
+            certified to the terms of the [Developer Certificate of
+            Origin][dco], version 1.1.  In particular, you certify that this
+            contribution has not been developed using information obtained
+            under a non-disclosure agreement or other license terms that
+            forbid you from contributing it under the [GNU Lesser General
+            Public License, version 2.1][license].
+
+
+            [commits]: ${{ github.server_url }}//${{ github.repository }}/compare/${{ steps.result.outputs.base }}...${{ steps.result.outputs.head }}
+
+            [signoff]: https://openslide.org/docs/signoff/
+
+            [dco]: https://openslide.org/docs/signoff/#developer-certificate-of-origin
+
+            [license]: https://openslide.org/license/
+
+      - name: Report bad signoff
+        uses: peter-evans/create-or-update-comment@v2
+        if: steps.result.outputs.success != 'true'
+        with:
+          issue-number: ${{ steps.result.outputs.pr }}
+          comment-id: ${{ steps.search.outputs.comment-id }}
+          edit-mode: replace
+          body: >
+            ## DCO not signed off :x:
+
+
+            [One or more commits][commits] have not been [signed
+            off][signoff].  All changes contributed to the OpenSlide project
+            must certify to the terms of the [Developer Certificate of
+            Origin][dco], version 1.1.  Note that by doing so, you certify
+            that this contribution has not been developed using information
+            obtained under a non-disclosure agreement or other license terms
+            that forbid you from contributing it under the [GNU Lesser
+            General Public License, version 2.1][license].
+
+
+            To certify to the Developer Certificate of Origin, add
+            `Signed-off-by: Your Name <your.email@example.com>` to each
+            commit message.  `git commit --signoff` will do this for you
+            automatically.
+
+
+            [commits]: ${{ github.server_url }}//${{ github.repository }}/compare/${{ steps.result.outputs.base }}...${{ steps.result.outputs.head }}
+
+            [signoff]: https://openslide.org/docs/signoff/
+
+            [dco]: https://openslide.org/docs/signoff/#developer-certificate-of-origin
+
+            [license]: https://openslide.org/license/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing to the OpenSlide project
+
+Thank you for contributing to the OpenSlide project!  For guidance on making
+and submitting your changes, please see the
+[OpenSlide developer guide](https://openslide.org/docs/devguide/).
+
+Every contribution to OpenSlide must include a
+[signoff](https://openslide.org/docs/signoff/) certifying that you have the
+right to contribute your changes to the project.  Note that by doing so, you
+certify that your contribution has not been developed using information
+obtained under a non-disclosure agreement or other license terms that forbid
+you from contributing it under the
+[GNU Lesser General Public License, version 2.1](https://openslide.org/license/).


### PR DESCRIPTION
If every commit in a PR has not been signed off by the author, fail CI, and also add a comment explaining what the contributor needs to assent to and how to do it.  If every commit has been signed off, add a comment explaining what the contributor has assented to, to ensure that the implications of a signoff are clear.  If such a comment already exists when the PR is updated, modify the existing comment rather than adding a new one.

Do the check in two parts: an unprivileged workflow that checks each commit and a privileged workflow that adds the PR comment.  The latter is done separately to avoid any possible privilege escalation from an untrusted PR.

Individual repositories need to explicitly invoke these reusable workflows; see the block comments for details.

Also add a CONTRIBUTING guide that mainly points to other resources, including DCO signoff instructions.

See https://github.com/openslide/openslide/issues/355 for more context.