### PR TITLE
workflows: avoid deprecated set-output command

### DIFF
--- a/.github/workflows/dco-report.yml
+++ b/.github/workflows/dco-report.yml
@@ -52,11 +52,11 @@ jobs:
         id: result
         run: |
           unzip -d result result.zip
-          echo "::set-output name=pr::$(cat result/pr)"
-          echo "::set-output name=base::$(cat result/base)"
-          echo "::set-output name=head::$(cat result/head)"
+          echo "pr=$(cat result/pr)" >> $GITHUB_OUTPUT
+          echo "base=$(cat result/base)" >> $GITHUB_OUTPUT
+          echo "head=$(cat result/head)" >> $GITHUB_OUTPUT
           if [ -e result/success ]; then
-              echo "::set-output name=success::true"
+              echo "success=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Find existing comment


### PR DESCRIPTION
[More info](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).