### PR TITLE
workflows/dco-report: use openslide-bot token to comment

### DIFF
--- a/.github/workflows/dco-report.yml
+++ b/.github/workflows/dco-report.yml
@@ -1,4 +1,5 @@
-# Privileged second part of dco-check.yml.  Architecture and code from
+# Privileged second part of dco-check.yml, using the OpenSlide bot token.
+# Architecture and code from
 # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 #
 # Invoke with:
@@ -9,17 +10,20 @@
 #         workflows: ["DCO"]
 #         types:
 #           - completed
-#     permissions:
-#       pull-requests: write
 #     jobs:
 #       comment:
 #         name: Organization
 #         uses: openslide/.github/.github/workflows/dco-report.yml@main
+#         secrets:
+#           OPENSLIDE_BOT_TOKEN: ${{ secrets.OPENSLIDE_BOT_TOKEN }}
 
 name: DCO report (reusable)
 
 on:
   workflow_call:
+    secrets:
+      OPENSLIDE_BOT_TOKEN:
+        required: true
 
 jobs:
   comment:
@@ -58,6 +62,11 @@ jobs:
           if [ -e result/success ]; then
               echo "success=true" >> $GITHUB_OUTPUT
           fi
+          if [ -n "${{ secrets.OPENSLIDE_BOT_TOKEN }}" ]; then
+              echo "have_token=true" >> $GITHUB_OUTPUT
+          else
+              echo "No bot token; not posting comment"
+          fi
 
       - name: Find existing comment
         uses: peter-evans/find-comment@v2
@@ -65,13 +74,14 @@ jobs:
         continue-on-error: true
         with:
           issue-number: ${{ steps.result.outputs.pr }}
-          comment-author: 'github-actions[bot]'
+          comment-author: 'openslide-bot'
           body-includes: Developer Certificate of Origin
 
       - name: Report good signoff
         uses: peter-evans/create-or-update-comment@v3
-        if: steps.result.outputs.success == 'true'
+        if: steps.result.outputs.success == 'true' && steps.result.outputs.have_token == 'true'
         with:
+          token: ${{ secrets.OPENSLIDE_BOT_TOKEN }}
           issue-number: ${{ steps.result.outputs.pr }}
           comment-id: ${{ steps.search.outputs.comment-id }}
           edit-mode: replace
@@ -98,8 +108,9 @@ jobs:
 
       - name: Report bad signoff
         uses: peter-evans/create-or-update-comment@v3
-        if: steps.result.outputs.success != 'true'
+        if: steps.result.outputs.success != 'true' && steps.result.outputs.have_token == 'true'
         with:
+          token: ${{ secrets.OPENSLIDE_BOT_TOKEN }}
           issue-number: ${{ steps.result.outputs.pr }}
           comment-id: ${{ steps.search.outputs.comment-id }}
           edit-mode: replace

--- a/.github/workflows/dco-report.yml
+++ b/.github/workflows/dco-report.yml
@@ -69,7 +69,7 @@ jobs:
           body-includes: Developer Certificate of Origin
 
       - name: Report good signoff
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v3
         if: steps.result.outputs.success == 'true'
         with:
           issue-number: ${{ steps.result.outputs.pr }}
@@ -97,7 +97,7 @@ jobs:
             [license]: https://openslide.org/license/
 
       - name: Report bad signoff
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v3
         if: steps.result.outputs.success != 'true'
         with:
           issue-number: ${{ steps.result.outputs.pr }}


### PR DESCRIPTION
We've been requiring PR write access to the repo, which allows us to arbitrarily modify PRs, but all we need to do is create or update a comment.  That can be done by a separate bot account that's completely unprivileged.

Use the @openslide-bot account token if available, and otherwise don't post a comment.  This also prevents the workflow from commenting on PRs in forks, which is useful to reduce noise.