### PR TITLE
workflows/dco-report: caller should drop permissions

### DIFF
--- a/.github/workflows/dco-report.yml
+++ b/.github/workflows/dco-report.yml
@@ -10,6 +10,8 @@
 #         workflows: ["DCO"]
 #         types:
 #           - completed
+#     permissions:
+#       contents: none
 #     jobs:
 #       comment:
 #         name: Organization


### PR DESCRIPTION
Depending on repo and org configuration, workflows may get write access to the repo by default.  Ensure this doesn't happen in forks.