### PR TITLE
workflows: switch to v4 artifact handling

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -39,7 +39,7 @@ jobs:
         dco-check -v
         touch result/success
     - name: Upload result
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: result

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -38,7 +38,8 @@ jobs:
         echo ${{ github.event.pull_request.head.sha }} > result/head
         dco-check -v
         touch result/success
-    - uses: actions/upload-artifact@v3
+    - name: Upload result
+      uses: actions/upload-artifact@v3
       if: always()
       with:
         name: result

--- a/.github/workflows/dco-report.yml
+++ b/.github/workflows/dco-report.yml
@@ -34,30 +34,16 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
     steps:
       - name: Download state
-        uses: actions/github-script@v7
+        uses: actions/download-artifact@v4
         with:
-          script: |
-            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: ${{ github.event.workflow_run.id }},
-            });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "result"
-            })[0];
-            var download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            var fs = require('fs');
-            fs.writeFileSync('${{ github.workspace }}/result.zip', Buffer.from(download.data));
+          name: result
+          path: result
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Read state
         id: result
         run: |
-          unzip -d result result.zip
           echo "pr=$(cat result/pr)" >> $GITHUB_OUTPUT
           echo "base=$(cat result/base)" >> $GITHUB_OUTPUT
           echo "head=$(cat result/head)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
upload-artifact v4 uses a new backend storage implementation.  download-artifact v4 supports downloading artifacts from a different workflow run, so we can use it to replace the open-coded github-script invocation.